### PR TITLE
Add option for logging download requests to console

### DIFF
--- a/Robust.Cdn/CdnOptions.cs
+++ b/Robust.Cdn/CdnOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Robust.Cdn;
+﻿using Robust.Cdn.Services;
+
+namespace Robust.Cdn;
 
 public sealed class CdnOptions
 {
@@ -69,9 +71,14 @@ public sealed class CdnOptions
     public float AutoStreamCompressRatio { get; set; } = 0.5f;
 
     /// <summary>
-    /// Log all download requests to the database.
+    /// Log all download requests
     /// </summary>
     public bool LogRequests { get; set; } = false;
+
+    /// <summary>
+    /// Log download requests to database or console
+    /// </summary>
+    public RequestLogStorage LogRequestStorage { get; set; } = RequestLogStorage.Database;
 
     /// <summary>
     /// Authentication token to initiate version updates via the POST /control/update endpoint.

--- a/Robust.Cdn/Services/RequestLogStorage.cs
+++ b/Robust.Cdn/Services/RequestLogStorage.cs
@@ -1,0 +1,7 @@
+﻿namespace Robust.Cdn.Services;
+
+public enum RequestLogStorage
+{
+    Database,
+    Console
+}


### PR DESCRIPTION
I'd like to enable the download request logging but I don't want to store the logs in SQLite, and since I'm already reading the logs with loki this creates the least intrusive change I can think.

The format when using `Console`:
```
# "RequestLog {Time} {Compression} {Protocol} {VersionId} {BytesSent} {DataSize} {Hash}"
RequestLog 2024-04-07T20:09:45.9497046Z Stream 1 3 124712622 88992 32C6A19C17947B7766FF510CDF7F9287F7BE0D837B838A70929124BCCAF2DA78
RequestLog 2024-04-07T20:06:55.3353128Z PreCompress 1 2 4 0 0E5751C026E543B2E8AB2EB06099DAA1D1E5DF47778F7787FAAB45CDF12FE3A8
```

And then you can extract all of it as labels through:
```
|~ `^\s*RequestLog` | pattern `      <_> <Time> <Compression> <Protocol> <VersionId> <BytesSent> <DataSize> <Hash>`
```

Which could then be analysed further or turned into a metric query

![image](https://github.com/space-wizards/Robust.Cdn/assets/905507/252a8f24-2a2c-4696-904c-78b25db0846e)
