### PR TITLE
Add common CPU brands next to architectures

### DIFF
--- a/Robust.Cdn/Views/ForkBuildPage/Index.cshtml
+++ b/Robust.Cdn/Views/ForkBuildPage/Index.cshtml
@@ -15,14 +15,14 @@
     {
         return rid switch
         {
-            "win-x64" => "Windows x64",
-            "win-arm64" => "Windows ARM64",
-            "linux-x64" => "Linux x64",
-            "linux-arm64" => "Linux ARM64",
+            "win-x64" => "Windows x64 (Intel, AMD)",
+            "win-arm64" => "Windows ARM64 (Snapdragon, etc)",
+            "linux-x64" => "Linux x64 (Intel, AMD)",
+            "linux-arm64" => "Linux ARM64 (Snapdragon, etc)",
             "osx-x64" => "macOS x64 (Intel)",
             "osx-arm64" => "macOS ARM64 (Apple Silicon)",
-            "freebsd-x64" => "FreeBSD x64",
-            "freebsd-arm64" => "FreeBSD ARM64",
+            "freebsd-x64" => "FreeBSD x64 (Intel, AMD)",
+            "freebsd-arm64" => "FreeBSD ARM64 (Snapdragon, etc)",
             _ => rid
         };
     }


### PR DESCRIPTION
Now that we are soon getting arm64 support, one common concern shared on the launcher side was people not understanding if their system was x64 or arm64.

Is this overboard? Probably, but it should clear confusion.

Hopefully intel or amd does not start making arm based processors soon. To my knowledge, only snapdragon is the only other brand selling arm64 based cpu's for computers at this current time, but to be sure i added "etc" because pretty much anything else will probably be arm64 in the coming years of technology by other brands.